### PR TITLE
UPNP Port Close Fix

### DIFF
--- a/src/com/dosse/upnp/UPnP.java
+++ b/src/com/dosse/upnp/UPnP.java
@@ -94,7 +94,7 @@ public class UPnP {
      */
     public static boolean closePortTCP(int port) {
         if(!isUPnPAvailable()) return false;
-        return defaultGW.closePort(port, true);
+        return defaultGW.closePort(port, false);
     }
     
     /**
@@ -106,7 +106,7 @@ public class UPnP {
      */
     public static boolean closePortUDP(int port) {
         if(!isUPnPAvailable()) return false;
-        return defaultGW.closePort(port, false);
+        return defaultGW.closePort(port, true);
     }
     
     /**


### PR DESCRIPTION
the booleans for close tcp and udp ports was inverted this fixes it.

Basically close UDP was calling close TCP and TCP calling close UDP

a try at fixing issue https://github.com/adolfintel/WaifUPnP/issues/2 since the booleans were inverted when closing