### PR TITLE
enhancements[refresh,upnp up now]

### DIFF
--- a/src/com/dosse/upnp/UPnP.java
+++ b/src/com/dosse/upnp/UPnP.java
@@ -27,7 +27,7 @@ package com.dosse.upnp;
 public class UPnP {
 
     private static Gateway defaultGW = null;
-    private static final GatewayFinder finder = new GatewayFinder() {
+    private static GatewayFinder finder = new GatewayFinder() {
         @Override
         public void gatewayFound(Gateway g) {
             synchronized (finder) {
@@ -37,6 +37,29 @@ public class UPnP {
             }
         }
     };
+    /**
+     * a dangerous check for is it open now at the current millisecond
+     */
+    public static boolean isUPnPUpNow(){
+    	return defaultGW != null;
+    }
+    /**
+     * this method will take a while to instantiate do not call unless necessary 
+     */
+    public static void refresh()
+    {
+    	defaultGW = null;
+    	finder = new GatewayFinder() {
+    	    @Override
+    	    public void gatewayFound(Gateway g) {
+    	        synchronized (finder) {
+    	            if (defaultGW == null) {
+    	                defaultGW = g;
+    	            }
+    	        }
+    	    }
+    	};
+    }
 
     /**
      * Waits for UPnP to be initialized (takes ~3 seconds).<br>


### PR DESCRIPTION
adds methods: 
refresh (refreshes the gatewayfinder and gateway to new objects)
upnp (a dangerous check for is upnp open at this ms)

I have a basic implementation of your library here if you wanted to update your readme file on how to use this library for other people. Note that the add schudule is minecraft specific since if it fails to port once then it refreshes UPnP when user re-opens to internet again else it doesn't refresh. 
https://github.com/jredfox/lanessentials/blob/master/src/main/java/com/EvilNotch/lanessentials/LanUtil.java

I used these in lan-essentials and thought it would be helpful 